### PR TITLE
fixing flow server integration

### DIFF
--- a/lib/linter-flow.coffee
+++ b/lib/linter-flow.coffee
@@ -31,6 +31,15 @@ class LinterFlow extends Linter
     child.stderr.on 'data', (x) -> str += x
 
     child.stdout.on 'close', (code) =>
+
+      if str.indexOf('Could not find a .flowconfig') >= 0
+        callback([])
+        return
+
+      if str and str.indexOf('{') > 0
+        # strip initial messages (eg. "server initializing...")
+        str = str.substr(str.indexOf('{'))
+
       console.log str
       info = JSON.parse(str)
       if info.passed


### PR DESCRIPTION
Hi, I've done some fixes to get this working with last flow version (0.3.0) and atom 0.180.0, here are the changes:
- handling server response (stripping initialization messages, when server takes too much time to start), handling .flowconfig not found (when you open a project, and then a file in a different path)
- `atom.project.getPath()`
- removing `--module node` parameter, it fails, that must be specified in the `.gitconfig` file now
- removing `--all` to avoid processing legacy project files (use `/* @flow */` comment)
cheers