### PR TITLE
Check if Flow is enabled before trying to stop it. Additions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ for Facebook's [Flow JS typechecker](http://flowtype.org/).
 
 ### How to use it
 
+1. [Install Flow](http://flowtype.org/docs/getting-started.html#installing-flow)
 1. Install the package
 1. Create an empty `.flowconfig` file at the root of your repo
 1. Open a JS file

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ for Facebook's [Flow JS typechecker](http://flowtype.org/).
 
 You should start seeing lint errors related to types - try opening the Flow
 example projects in Atom
+
+### Troubleshooting
+
+###### OS X: No lint errors are shown?
+> Try launching Atom from the terminal. Alternative workarounds here: [atom/atom-shell#550](https://github.com/atom/atom-shell/issues/550)

--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ example projects in Atom
 
 ### Troubleshooting
 
-###### OS X: No lint errors are shown?
-> Try launching Atom from the terminal. Alternative workarounds here: [atom/atom-shell#550](https://github.com/atom/atom-shell/issues/550)
+##### OS X: No lint errors are shown?
+* **Possible cause:** The PATH to your Flow executable cannot be found.
+* **Solution:** Try launching Atom from the terminal. Alternative workarounds here: [atom/atom-shell#550](https://github.com/atom/atom-shell/issues/550)

--- a/lib/linter-flow.coffee
+++ b/lib/linter-flow.coffee
@@ -115,7 +115,8 @@ class LinterFlow extends Linter
     flowServer.on 'close', (code) => @flowEnabled &= (code is 2)
 
   destroy: ->
-    spawn(@flowPath, ['--stop', path.resolve(atom.project.getPath())])
-    console.log "die"
+    if @flowEnabled
+      spawn(@flowPath, ['--stop', path.resolve(atom.project.getPath())])
+      console.log "die"
 
 module.exports = LinterFlow


### PR DESCRIPTION
Fixes #7 and fixes #8 

**Cause of the error:** The variable flowPath is not always defined.

With the additional condition it won't throw an Error anymore, but flow still won't be enabled as expected.
I have added additional information in the README, which explains to steps that need to be taken in order for it to work properly.