### PR TITLE
fix #6

### DIFF
--- a/lib/linter-flow.coffee
+++ b/lib/linter-flow.coffee
@@ -111,8 +111,8 @@ class LinterFlow extends Linter
 
     @flowPath = path.join(@flowPath, 'flow')
 
-    flowServer = spawn(@flowPath, ['start', '--all', '--module', 'node', path.resolve(atom.project.getPaths()[0])])
-    flowServer.on 'close', (code) => @flowEnabled &= (code is 2)
+    flowServer = spawn(@flowPath, ['start', path.resolve(atom.project.getPaths()[0])])
+    flowServer.on 'close', (code) => @flowEnabled &= (code is 0)
 
   destroy: ->
     if @flowEnabled


### PR DESCRIPTION
* remove `--all`, flow should be configured by the `.flowconfig` file
* remove `--module`, at least flow 0.11.0 does not know this option
* flow returns 0 after successfully starting the server, so check for that instead of 2