### PR TITLE
Servers spawn now includes cwd for relative paths

### DIFF
--- a/lib/servers.js
+++ b/lib/servers.js
@@ -17,13 +17,14 @@ export function start(pathToFlow: string, flowConfig: string, enableAll: boolean
     }
 
     atom.notifications.addInfo(`[Linter-Flow] Starting Flow server for: ${flowConfigPath}`);
-
+    
+    const opts = {cwd: flowConfigPath};
     let args = ['server', flowConfig];
     if (enableAll) {
       args = [...args, '--all'];
     }
 
-    const serverProcess = spawn(pathToFlow, args, {cwd: flowConfigPath});
+    const serverProcess = spawn(pathToFlow, args, opts);
     function handleMsg(data: any) {
       const message = data.toString();
       if (message.indexOf('another server is already running?') > -1) {

--- a/lib/servers.js
+++ b/lib/servers.js
@@ -23,7 +23,7 @@ export function start(pathToFlow: string, flowConfig: string, enableAll: boolean
       args = [...args, '--all'];
     }
 
-    const serverProcess = spawn(pathToFlow, args);
+    const serverProcess = spawn(pathToFlow, args, {cwd:flowConfigPath});
     function handleMsg(data: any) {
       const message = data.toString();
       if (message.indexOf('another server is already running?') > -1) {

--- a/lib/servers.js
+++ b/lib/servers.js
@@ -23,7 +23,7 @@ export function start(pathToFlow: string, flowConfig: string, enableAll: boolean
       args = [...args, '--all'];
     }
 
-    const serverProcess = spawn(pathToFlow, args, {cwd:flowConfigPath});
+    const serverProcess = spawn(pathToFlow, args, {cwd: flowConfigPath});
     function handleMsg(data: any) {
       const message = data.toString();
       if (message.indexOf('another server is already running?') > -1) {

--- a/lib/servers.js
+++ b/lib/servers.js
@@ -17,8 +17,8 @@ export function start(pathToFlow: string, flowConfig: string, enableAll: boolean
     }
 
     atom.notifications.addInfo(`[Linter-Flow] Starting Flow server for: ${flowConfigPath}`);
-    
-    const opts = {cwd: flowConfigPath};
+
+    const opts = { cwd: flowConfigPath };
     let args = ['server', flowConfig];
     if (enableAll) {
       args = [...args, '--all'];


### PR DESCRIPTION
Workaround for https://github.com/AtomLinter/linter-flow/issues/67 which allows people to do `./node_modules/.bin/flow` as their flow path