### PR TITLE
Don't rely on buffers having cached text

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ export default {
       lintOnFly: true,
       lint: (TextEditor) => {
         const filePath = TextEditor.getPath();
-        const fileText = TextEditor.buffer.cachedText;
+        const fileText = TextEditor.getText();
 
         // Is flow enabled for current file ?
         const firstComStart = fileText.indexOf('\/*');


### PR DESCRIPTION
I'm using `linter-flow` with atom 1.6 and 1.7 beta and often my screen gets flooded with:

```
TypeError: Cannot read property 'indexOf' of null
    at Object.lint (.../linter-flow/lib/index.js:76:39)
    ...
```

The code in question is this:

```javascript
        const fileText = TextEditor.buffer.cachedText;

        // Is flow enabled for current file ?
        const firstComStart = fileText.indexOf('\/*');
```

If you look at `TextBuffer`'s source code it is not guaranteed to have the `cachedText` ready unless `getText` was called at least once. If you look at the `getText` implementation you will notice that it does return the cached value when it's available. Seeing as `TextEditor.getText` is a convenience wrapper for `@buffer.getText()`, I propose to replace the call with `TextEditor.getText()`.