### PR TITLE
Fix @flow detection, add //@flow support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,6 @@ export default {
         if (firstMComStart === -1 ||
           firstMComEnd === -1 ||
           fileText.slice(firstMComStart + 2, firstMComEnd).indexOf('@flow') === -1) {
-
           // Check in first single-line comment.
           const firstSComStart = fileText.indexOf('\/\/');
           const firstSComEnd = firstSComStart + fileText.slice(firstSComStart).indexOf('\n');

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,8 +75,8 @@ export default {
         // Is flow enabled for current file ?
         const firstComStart = fileText.indexOf('\/*');
         const firstComEnd = fileText.indexOf('*\/');
-        if (firstComStart !== -1 &&
-          firstComEnd !== -1 &&
+        if (firstComStart === -1 ||
+          firstComEnd === -1 ||
           fileText.slice(firstComStart + 2, firstComEnd).indexOf('@flow') === -1) {
           return Promise.resolve([]);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,12 +73,23 @@ export default {
         const fileText = TextEditor.getText();
 
         // Is flow enabled for current file ?
-        const firstComStart = fileText.indexOf('\/*');
-        const firstComEnd = fileText.indexOf('*\/');
-        if (firstComStart === -1 ||
-          firstComEnd === -1 ||
-          fileText.slice(firstComStart + 2, firstComEnd).indexOf('@flow') === -1) {
-          return Promise.resolve([]);
+        // Check in first multi-line comment.
+        const firstMComStart = fileText.indexOf('\/*');
+        const firstMComEnd = fileText.indexOf('*\/');
+        if (firstMComStart === -1 ||
+          firstMComEnd === -1 ||
+          fileText.slice(firstMComStart + 2, firstMComEnd).indexOf('@flow') === -1) {
+
+          // Check in first single-line comment.
+          const firstSComStart = fileText.indexOf('\/\/');
+          const firstSComEnd = firstSComStart + fileText.slice(firstSComStart).indexOf('\n');
+          if (firstSComStart === -1 ||
+            fileText.slice(firstSComStart + 2, firstSComEnd).indexOf('@flow') === -1
+            ) {
+            // Failed to find @flow in the first single-line or multi-line comment.
+            // Don't treat this as a flow file.
+            return Promise.resolve([]);
+          }
         }
 
         // Check if .flowconfig file is present


### PR DESCRIPTION
* Fixes the bug where linter-flow would detect all files that didn't start with a multi-line comment as a flow file: https://github.com/AtomLinter/linter-flow/issues/75
* Fixes the bug where linter-flow wouldn't detect //@flow.

Disclaimer: I didn't really test this out besides by running the project's tests.