### PR TITLE
fix(cwd): use folder containing .flowconfig to run flow

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,19 +1,30 @@
 'use babel';
 /* @flow */
-
 const helpers = require('atom-linter');
 
-export function check(pathToFlow: string, args: Array<string>, options: Object): Promise<string> {
+export function check(
+  pathToFlow: string,
+  args: Array<string>,
+  options: Object,
+  startTime: number = Date.now()
+): Promise<string> {
   return helpers
     .exec(pathToFlow, args, options)
     .catch((error: string | Object) => {
       const errorM: string = String(error).toLowerCase();
+
+      // If we'be been waiting for more than 10 seconds, just give up
+      if (Date.now() - startTime > 10000) {
+        return '[]';
+      }
+      // Check for the common flow status messages and ignore them
       if (errorM.indexOf('rechecking') !== -1 ||
         errorM.indexOf('launching') !== -1 ||
         errorM.indexOf('processing') !== -1 ||
         errorM.indexOf('starting') !== -1 ||
         errorM.indexOf('spawned') !== -1 ||
-        errorM.indexOf('logs') !== -1
+        errorM.indexOf('logs') !== -1 ||
+        errorM.indexOf('initializing') !== -1
       ) {
         return check(pathToFlow, args, options);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ export default {
     require('atom-package-deps').install('linter-flow');
 
     this.lastConfigError = {};
+    this.flowInstances = new Set();
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe('linter-flow.executablePath', (pathToFlow) => {
@@ -55,7 +56,12 @@ export default {
     if (atom.inDevMode()) {
       console.log('deactivating... linter-flow');
     }
-    helpers.exec(this.pathToFlow, ['stop'], {}).catch(() => null);
+    const flowInstances: Set = this.flowInstances;
+    flowInstances.forEach((cwd) =>
+      helpers
+        .exec(this.pathToFlow, ['stop'], { cwd })
+        .catch(() => null)
+    );
     this.subscriptions.dispose();
   },
 
@@ -100,6 +106,8 @@ export default {
         let options;
 
         const cwd = path.dirname(flowConfig);
+        const flowInstances: Set = this.flowInstances;
+        flowInstances.add(cwd);
         // Use `check-contents` for unsaved files. and `status` for savatom.project.getPaths()
         if (TextEditor.isModified()) {
           args = ['check-contents', '--json', filePath];

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ type BufferType = {
 
 type TextEditorType = {
   getPath(): string;
+  getText(): string;
   buffer: BufferType;
   isModified(): boolean;
 }
@@ -98,13 +99,14 @@ export default {
         let args;
         let options;
 
-        // Use `check-contents` for unsaved files. and `status` for saved files.
+        const cwd = path.dirname(flowConfig);
+        // Use `check-contents` for unsaved files. and `status` for savatom.project.getPaths()
         if (TextEditor.isModified()) {
           args = ['check-contents', '--json', filePath];
-          options = { cwd: path.dirname(filePath), stdin: fileText };
+          options = { cwd, stdin: fileText };
         } else {
           args = ['status', '--json', filePath];
-          options = { cwd: path.dirname(filePath) };
+          options = { cwd };
         }
 
         return check(this.pathToFlow, args, options)

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-eslint": "6.0.0-beta.6",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.1.0",
-    "eslint-plugin-react": "^4.2.3"
+    "eslint-plugin-react": "^4.2.3",
+    "flow-bin": "^0.24.2"
   }
 }

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -18,11 +18,11 @@ describe('Flow provider for Linter', () => {
       atom.workspace.open(constructorPath).then(editor =>
         lint(editor).then(messages => {
           expect(messages.length).toEqual(1);
-          expect(messages[0].type).toEqual('Error');
+          expect(messages[0].type).toEqual('Warning');
           expect(messages[0].text)
-            .toEqual('return undefined This type is incompatible with number');
+            .toEqual('number This type is incompatible with an implicitly-returned undefined.');
           expect(messages[0].filePath).toMatch(/.+constructor\.js$/);
-          expect(messages[0].trace.length).toEqual(2);
+          expect(messages[0].trace.length).toEqual(1);
           expect(messages[0].range).toEqual({
             start: { row: 6, column: 18 },
             end: { row: 6, column: 24 },
@@ -37,7 +37,7 @@ describe('Flow provider for Linter', () => {
       atom.workspace.open(arrayPath).then(editor =>
         lint(editor).then(messages => {
           expect(messages.length).toEqual(1);
-          expect(messages[0].type).toEqual('Error');
+          expect(messages[0].type).toEqual('Warning');
           expect(messages[0].text).toEqual('number This type is incompatible with string');
           expect(messages[0].filePath).toMatch(/.+Arrays\.js$/);
           expect(messages[0].trace.length).toEqual(2);


### PR DESCRIPTION
Pretty simple fix really.

Switched out `path.dirname(filePath)` for `path.dirname(flowConfig)` and voila, `./node_modules/.bin/flow` now works.

Obviously this comes with the caveat that `.flowconfig` should live in the root of your project folder along with the the node_modules folder. OR you could put the relative path from the .flowconfig to the flow executable.

I think we can automate this in the future. We could look for the node_modules directory automatically, and given an option, use the locally installed version of flow.

NOTE: not sure if the `flow stop` command works correctly for now. Working on that now.