### PR TITLE
Report all blames as error messages

### DIFF
--- a/declarations/modules.js
+++ b/declarations/modules.js
@@ -30,3 +30,7 @@ declare module 'atom-linter' {
   declare function find(filePath: string, fileName: string): ?string;
   declare function exec(executable: string, args?: Array<string>, config?: Object): Promise<string>;
 }
+
+declare module 'lodash.flatten' {
+  declare var exports: <T>(array: Array<T | T[]>) => T[]
+};

--- a/lib/message.js
+++ b/lib/message.js
@@ -2,9 +2,9 @@
 /* @flow */
 
 import { Range } from 'atom';
+import flatten from 'lodash.flatten';
 
 import type { FlowError, LinterTrace, LinterMessage } from './types.js';
-
 
 function extractRange(message: FlowError): Range {
   return new Range(
@@ -23,22 +23,22 @@ function flowMessageToTrace(message: FlowError): LinterTrace {
 }
 
 function flowMessageToLinterMessage({ message: flowMessages }): LinterMessage {
-  const flowMessage = flowMessages[0];
+  const blameMessages = flowMessages.filter(m => m.type === 'Blame');
 
-  return {
+  return blameMessages.map((flowMessage, i) => ({
     type: flowMessage.level === 'error' ? 'Error' : 'Warning',
     text: flowMessages.map(msg => msg.descr).join(' '),
     filePath: flowMessage.path || null,
     range: extractRange(flowMessage),
-    trace: flowMessages.slice(1).map(flowMessageToTrace),
-  };
+    trace: [...blameMessages.slice(0, i), ...blameMessages.slice(i + 1)].map(flowMessageToTrace),
+  }));
 }
 
 function handleData(json: any): Array<LinterMessage> {
   if (json.passed || !json.errors) {
     return [];
   }
-  return json.errors.map(flowMessageToLinterMessage);
+  return flatten(json.errors.map(flowMessageToLinterMessage));
 }
 
 export default handleData;

--- a/lib/message.js
+++ b/lib/message.js
@@ -22,7 +22,7 @@ function flowMessageToTrace(message: FlowError): LinterTrace {
   };
 }
 
-function flowMessageToLinterMessage({ message: flowMessages }): LinterMessage {
+function flowMessageToLinterMessages({ message: flowMessages }): LinterMessage {
   const blameMessages = flowMessages.filter(m => m.type === 'Blame');
 
   return blameMessages.map((flowMessage, i) => ({
@@ -38,7 +38,7 @@ function handleData(json: any): Array<LinterMessage> {
   if (json.passed || !json.errors) {
     return [];
   }
-  return flatten(json.errors.map(flowMessageToLinterMessage));
+  return flatten(json.errors.map(flowMessageToLinterMessages));
 }
 
 export default handleData;

--- a/lib/message.js
+++ b/lib/message.js
@@ -22,7 +22,7 @@ function flowMessageToTrace(message: FlowError): LinterTrace {
   };
 }
 
-function flowMessageToLinterMessages({ message: flowMessages }): LinterMessage {
+function flowMessageToLinterMessages({ message: flowMessages }): Array<LinterMessage> {
   const blameMessages = flowMessages.filter(m => m.type === 'Blame');
 
   return blameMessages.map((flowMessage, i) => ({

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "atom-linter": "^4.4.0",
-    "atom-package-deps": "^4.0.1"
+    "atom-package-deps": "^4.0.1",
+    "lodash.flatten": "^4.2.0"
   },
   "package-deps": [
     "linter"

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -16,12 +16,12 @@ describe('Flow provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(constructorPath).then(editor =>
         lint(editor).then(messages => {
-          expect(messages.length).toEqual(1);
-          expect(messages[0].type).toEqual('Warning');
+          expect(messages.length).toBe(1);
+          expect(messages[0].type).toBe('Warning');
           expect(messages[0].text)
-            .toEqual('number This type is incompatible with an implicitly-returned undefined.');
+            .toBe('number This type is incompatible with an implicitly-returned undefined.');
           expect(messages[0].filePath).toMatch(/.+constructor\.js$/);
-          expect(messages[0].trace.length).toEqual(0);
+          expect(messages[0].trace.length).toBe(0);
           expect(messages[0].range).toEqual({
             start: { row: 6, column: 18 },
             end: { row: 6, column: 24 },
@@ -35,12 +35,12 @@ describe('Flow provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(arrayPath).then(editor =>
         lint(editor).then(messages => {
-          expect(messages.length).toEqual(2);
+          expect(messages.length).toBe(2);
 
-          expect(messages[0].type).toEqual('Warning');
-          expect(messages[0].text).toEqual('number This type is incompatible with string');
+          expect(messages[0].type).toBe('Warning');
+          expect(messages[0].text).toBe('number This type is incompatible with string');
           expect(messages[0].filePath).toMatch(/.+Arrays\.js$/);
-          expect(messages[0].trace.length).toEqual(1);
+          expect(messages[0].trace.length).toBe(1);
           expect(messages[0].trace[0].range).toEqual({
             start: { row: 3, column: 16 },
             end: { row: 3, column: 22 },
@@ -50,10 +50,10 @@ describe('Flow provider for Linter', () => {
             end: { row: 9, column: 8 },
           });
 
-          expect(messages[1].type).toEqual('Warning');
-          expect(messages[0].text).toEqual('number This type is incompatible with string');
+          expect(messages[1].type).toBe('Warning');
+          expect(messages[0].text).toBe('number This type is incompatible with string');
           expect(messages[0].filePath).toMatch(/.+Arrays\.js$/);
-          expect(messages[0].trace.length).toEqual(1);
+          expect(messages[0].trace.length).toBe(1);
           expect(messages[1].trace[0].range).toEqual({
             start: { row: 9, column: 4 },
             end: { row: 9, column: 8 },

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -21,7 +21,7 @@ describe('Flow provider for Linter', () => {
           expect(messages[0].text)
             .toEqual('number This type is incompatible with an implicitly-returned undefined.');
           expect(messages[0].filePath).toMatch(/.+constructor\.js$/);
-          expect(messages[0].trace.length).toEqual(1);
+          expect(messages[0].trace.length).toEqual(0);
           expect(messages[0].range).toEqual({
             start: { row: 6, column: 18 },
             end: { row: 6, column: 24 },
@@ -35,14 +35,32 @@ describe('Flow provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(arrayPath).then(editor =>
         lint(editor).then(messages => {
-          expect(messages.length).toEqual(1);
+          expect(messages.length).toEqual(2);
+
           expect(messages[0].type).toEqual('Warning');
           expect(messages[0].text).toEqual('number This type is incompatible with string');
           expect(messages[0].filePath).toMatch(/.+Arrays\.js$/);
-          expect(messages[0].trace.length).toEqual(2);
+          expect(messages[0].trace.length).toEqual(1);
+          expect(messages[0].trace[0].range).toEqual({
+            start: { row: 3, column: 16 },
+            end: { row: 3, column: 22 },
+          });
           expect(messages[0].range).toEqual({
             start: { row: 9, column: 4 },
             end: { row: 9, column: 8 },
+          });
+
+          expect(messages[1].type).toEqual('Warning');
+          expect(messages[0].text).toEqual('number This type is incompatible with string');
+          expect(messages[0].filePath).toMatch(/.+Arrays\.js$/);
+          expect(messages[0].trace.length).toEqual(1);
+          expect(messages[1].trace[0].range).toEqual({
+            start: { row: 9, column: 4 },
+            end: { row: 9, column: 8 },
+          });
+          expect(messages[1].range).toEqual({
+            start: { row: 3, column: 16 },
+            end: { row: 3, column: 22 },
           });
         })
       )


### PR DESCRIPTION
Right now only the first blame location in a Flow error is displayed in the UI. This PR shows all blame locations correctly and includes other blames in the error as traces. Also, comment texts are removed from traces.