### PR TITLE
fix(error-handling): Don't re-check flow for any error.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,17 +17,17 @@ export default function check(
       if (Date.now() - startTime > 10000) {
         return '[]';
       }
-      // Check for the common flow status messages and ignore them
-      if (errorM.indexOf('rechecking') !== -1 ||
-        errorM.indexOf('launching') !== -1 ||
-        errorM.indexOf('processing') !== -1 ||
-        errorM.indexOf('starting') !== -1 ||
-        errorM.indexOf('spawned') !== -1 ||
-        errorM.indexOf('logs') !== -1 ||
-        errorM.indexOf('initializing') !== -1
-      ) {
-        return check(pathToFlow, args, options);
-      }
+      // // Check for the common flow status messages and ignore them
+      // if (errorM.indexOf('rechecking') !== -1 ||
+      //   errorM.indexOf('launching') !== -1 ||
+      //   errorM.indexOf('processing') !== -1 ||
+      //   errorM.indexOf('starting') !== -1 ||
+      //   errorM.indexOf('spawned') !== -1 ||
+      //   errorM.indexOf('logs') !== -1 ||
+      //   errorM.indexOf('initializing') !== -1
+      // ) {
+      //   return check(pathToFlow, args, options);
+      // }
       throw error;
     });
 }


### PR DESCRIPTION
The linter used to recheck flow when the server was initializing.
This could cause massive CPU usage.

fixes #114