### PR TITLE
chore(package): update flow-bin to version 0.44.0

### DIFF
--- a/declarations/modules.js
+++ b/declarations/modules.js
@@ -30,7 +30,3 @@ declare module 'atom-linter' {
   declare function find(filePath: string, fileName: string): ?string;
   declare function exec(executable: string, args?: Array<string>, config?: Object): Promise<string>;
 }
-
-declare module 'lodash.flatten' {
-  declare var exports: <T>(array: Array<T | T[]>) => T[]
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-'use babel';
-
 // eslint-disable-next-line import/extensions
 import { CompositeDisposable } from 'atom';
 import path from 'path';

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,21 +1,18 @@
 /* @flow */
 
-'use babel';
-
 // eslint-disable-next-line import/extensions
 import { Range } from 'atom';
-import flatten from 'lodash.flatten';
 
-import type { FlowError, LinterTrace, LinterMessage } from './types';
+import type { FlowError, FlowMessage, LinterTrace, LinterMessageV1 } from './types';
 
-function extractRange(message: FlowError): Range {
+function extractRange(message: FlowMessage): Range {
   return new Range(
     [message.line - 1, message.start - 1],
     [message.endline - 1, message.end],
   );
 }
 
-function flowMessageToTrace(message: FlowError): LinterTrace {
+function flowMessageToTrace(message: FlowMessage): LinterTrace {
   return {
     type: 'Trace',
     text: message.descr,
@@ -24,23 +21,24 @@ function flowMessageToTrace(message: FlowError): LinterTrace {
   };
 }
 
-function flowMessageToLinterMessages({ message: flowMessages }): Array<LinterMessage> {
-  const blameMessages = flowMessages.filter(m => m.type === 'Blame');
+function flowErrorToLinterMessages(flowError: FlowError): Array<LinterMessageV1> {
+  const blameMessages = flowError.message.filter((m: FlowMessage) => m.type === 'Blame');
 
-  return blameMessages.map((flowMessage, i) => ({
-    type: flowMessage.level === 'error' ? 'Error' : 'Warning',
-    text: flowMessages.map(msg => msg.descr).join(' '),
-    filePath: flowMessage.path || null,
-    range: extractRange(flowMessage),
+  return blameMessages.map((message: FlowMessage, i) => ({
+    type: flowError.level === 'error' ? 'Error' : 'Warning',
+    text: flowError.message.map((msg: FlowMessage) => msg.descr).join(' '),
+    filePath: message.path || null,
+    range: extractRange(message),
     trace: [...blameMessages.slice(0, i), ...blameMessages.slice(i + 1)].map(flowMessageToTrace),
   }));
 }
 
-function handleData(json: any): Array<LinterMessage> {
+function handleData(json: any): Array<LinterMessageV1> {
   if (json.passed || !json.errors) {
     return [];
   }
-  return flatten(json.errors.map(flowMessageToLinterMessages));
+  return json.errors.reduce((messages, error) =>
+    messages.concat(flowErrorToLinterMessages(error)), []);
 }
 
 export default handleData;

--- a/lib/types.js
+++ b/lib/types.js
@@ -9,7 +9,7 @@ export type LinterTrace = {
   range?: Range;
 };
 
-export type LinterMessage = {
+export type LinterMessageV1 = {
   type: 'Error' | 'Warning';
   text?: string;
   html?: string;
@@ -18,15 +18,35 @@ export type LinterMessage = {
   trace?: Array<LinterTrace>;
 };
 
-export type FlowError = {
-  level: string;
-  descr: string;
-  path: string;
+export type FlowPoint = {
+  column: number;
   line: number;
-  start: number;
-  endline: number;
+  offset: number;
+}
+
+export type FlowLocation = {
+  end: FlowPoint;
+  source: string;
+  start: FlowPoint;
+}
+
+export type FlowMessage = {
+  context: string;
+  descr: string;
   end: number;
+  endline: number;
+  line: number;
+  loc?: FlowLocation;
+  path: string;
+  start: number;
+  type: string;
 };
+
+export type FlowError = {
+  kind: string;
+  level: string;
+  message: Array<FlowMessage>;
+}
 
 export type BufferType = {
   cachedText: string;
@@ -45,5 +65,5 @@ export type Linter = {
   scope: 'file' | 'project';
   name?: string;
   lintOnFly: boolean;
-  lint(TextEditor: TextEditorType): Array<LinterMessage> | Promise<Array<LinterMessage>>;
+  lint(TextEditor: TextEditorType): Array<LinterMessageV1> | Promise<Array<LinterMessageV1>>;
 };

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.0.1",
-    "lodash.flatten": "^4.2.0"
+    "atom-package-deps": "^4.0.1"
   },
   "package-deps": [
     "linter"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^3.16.1",
     "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.0.1",
-    "flow-bin": "^0.42.0"
+    "flow-bin": "^0.44.0"
   },
   "eslintConfig": {
     "extends": "airbnb-base",

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -26,7 +26,7 @@ describe('Flow provider for Linter', () => {
       atom.workspace.open(constructorPath).then(editor =>
         lint(editor).then((messages) => {
           expect(messages.length).toBe(1);
-          expect(messages[0].type).toBe('Warning');
+          expect(messages[0].type).toBe('Error');
           expect(messages[0].text).toBe(msgText);
           expect(messages[0].filePath).toBe(constructorPath);
           expect(messages[0].trace.length).toBe(0);
@@ -43,14 +43,14 @@ describe('Flow provider for Linter', () => {
         lint(editor).then((messages) => {
           expect(messages.length).toBe(2);
 
-          expect(messages[0].type).toBe('Warning');
+          expect(messages[0].type).toBe('Error');
           expect(messages[0].text).toBe(msgText);
           expect(messages[0].filePath).toBe(arrayPath);
           expect(messages[0].trace.length).toBe(1);
           expect(messages[0].trace[0].range).toEqual([[3, 16], [3, 22]]);
           expect(messages[0].range).toEqual([[9, 4], [9, 8]]);
 
-          expect(messages[1].type).toBe('Warning');
+          expect(messages[1].type).toBe('Error');
           expect(messages[1].text).toBe(msgText);
           expect(messages[1].filePath).toBe(arrayPath);
           expect(messages[1].trace.length).toBe(1);


### PR DESCRIPTION
Updates to `flow-bin@^0.44.0`. Needs to be explicitly done as there are [reports](https://github.com/AtomLinter/linter-flow/issues/162) that this version changes message attributes that are relied on.

Closes #160