### PR TITLE
Support local flow path

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -37,9 +37,7 @@ export default function check(
     });
 }
 
-export function findFlowPath(
-  filePath: string,
-): string {
+export function findFlowPath(filePath: string): string {
   const fileDir = Path.dirname(filePath);
   const modulesDir = Path.dirname(findCached(fileDir, 'node_modules/flow-bin') || '');
   return Path.join(modulesDir || '', 'flow-bin/cli.js');

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,7 +7,7 @@ import { findCached } from 'atom-linter';
 
 const helpers = require('atom-linter');
 
-export function check(
+export default function check(
   pathToFlow: string,
   args: Array<string>,
   options: Object,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,9 +2,12 @@
 
 'use babel';
 
+import Path from 'path';
+import { findCached } from 'atom-linter';
+
 const helpers = require('atom-linter');
 
-export default function check(
+export function check(
   pathToFlow: string,
   args: Array<string>,
   options: Object,
@@ -32,4 +35,12 @@ export default function check(
       }
       throw error;
     });
+}
+
+export function findFlowPath(
+  filePath: string,
+): any {
+  const fileDir = Path.dirname(filePath);
+  const modulesDir = Path.dirname(findCached(fileDir, 'node_modules/flow-bin') || '');
+  return Path.join(modulesDir || '', 'flow-bin/cli.js');
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,7 +39,7 @@ export default function check(
 
 export function findFlowPath(
   filePath: string,
-): any {
+): string {
   const fileDir = Path.dirname(filePath);
   const modulesDir = Path.dirname(findCached(fileDir, 'node_modules/flow-bin') || '');
   return Path.join(modulesDir || '', 'flow-bin/cli.js');

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,8 +111,6 @@ export default {
             this.pathToFlow :
             findFlowPath(filePath);
 
-        console.log(this.useGlobalFlow, flowPath);
-
         return check(flowPath, args, options)
           .then(JSON.parse)
           .then(handleData);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ import path from 'path';
 
 import handleData from './message';
 import type { Linter } from './types';
-import { check, findFlowPath } from './helpers';
+import check, { findFlowPath } from './helpers';
 
 export default {
   config: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ import path from 'path';
 
 import handleData from './message';
 import type { Linter } from './types';
-import check from './helpers';
+import { check, findFlowPath } from './helpers';
 
 export default {
   config: {
@@ -14,6 +14,12 @@ export default {
       type: 'string',
       default: 'flow',
       description: 'Absolute path to the Flow executable on your system.',
+    },
+    useGlobalFlow: {
+      title: 'Use global flow installation',
+      type: 'boolean',
+      default: false,
+      description: 'Make sure you have it in your $PATH',
     },
   },
 
@@ -26,6 +32,9 @@ export default {
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe('linter-flow.executablePath', (pathToFlow) => {
       this.pathToFlow = pathToFlow;
+    }));
+    this.subscriptions.add(atom.config.observe('linter-flow.useGlobalFlow', (useGlobalFlow) => {
+      this.useGlobalFlow = useGlobalFlow;
     }));
   },
 
@@ -97,7 +106,14 @@ export default {
           options = { cwd, ignoreExitCode: true };
         }
 
-        return check(this.pathToFlow, args, options)
+        const flowPath =
+          this.useGlobalFlow ?
+            this.pathToFlow :
+            findFlowPath(filePath);
+
+        console.log(this.useGlobalFlow, flowPath);
+
+        return check(flowPath, args, options)
           .then(JSON.parse)
           .then(handleData);
       },


### PR DESCRIPTION
Basing this off of `linter-eslint` to support a local flow path. Adds `findFlowPath` that accepts the file being linted to find `flow` bin in the corresponding modules directory. Need to ensure it still works with a global installation. There are also most likely edge cases that I do not yet understand as the `linter-eslint` code is complicated in this area